### PR TITLE
Quick fix for a crash

### DIFF
--- a/lib/google_custom_search_api.rb
+++ b/lib/google_custom_search_api.rb
@@ -41,7 +41,7 @@ module GoogleCustomSearchApi
       # results = ResponseData.new(read_search_data("google_poker_#{opts[:start]}"))
       yield results
       res << results
-      if results.queries.keys.include?("nextPage")
+      if results["queries"] and results.queries.keys.include?("nextPage")
         opts[:start] = results.queries.nextPage.first.startIndex
       else
         opts[:start] = nil


### PR DESCRIPTION
In some cases, `queries' is not a key of the result – causing a crash!
