### PR TITLE
Choosing from multiple engines

### DIFF
--- a/lib/google_custom_search_api.rb
+++ b/lib/google_custom_search_api.rb
@@ -114,6 +114,7 @@ module GoogleCustomSearchApi
     else
       api_key = opts[:engine_keys]["GOOGLE_API_KEY"]
       search_cx = opts[:engine_keys]["GOOGLE_SEARCH_CX"]
+      opts.delete(:engine_keys)
     end
     uri = Addressable::URI.new
     uri.query_values = opts


### PR DESCRIPTION
Hi nice library you have.

I had a need to use multiple search engines and single constant was not working for me.

This would be alternative syntax:
GOOGLE_ENGINES = {
  :japanese => { "GOOGLE_API_KEY" => "zz", "GOOGLE_SEARCH_CX" => "yy" },
  :chinese => { "GOOGLE_API_KEY" => "bb", "GOOGLE_SEARCH_CX" => "ee" } 
}

and then on search:

GoogleCustomSearchApi.search(title, :engine_keys => GOOGLE_ENGINES[:japanese])

Sorry about my editor being a whitespace nazzi, the changes are only in url method. 
