### PR TITLE
Supply api options via hash

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,11 @@ You can get your ```GOOGLE_API_KEY``` from https://code.google.com/apis/console/
 
 You can get your ```GOOGLE_SEARCH_CX``` from http://www.google.com/cse/  Either create a custom engine or follow ```manage your existing search engines``` and go to your cse's Control panel.  ```GOOGLE_SEARCH_CX``` == ```Search engine unique ID```
 
+Alternatively you can supply a key to the `search` function. `api_key` and `cx_id`
+
+    results = GoogleCustomSearchApi.search("poker", {api_key: "", cx_id: ""})
+
+
 ### Searching the web, not just your site, with CSE
 
 Google CSE was set up so search specific sites.  To search the entire web simply go to http://www.google.com/cse/, find your CSE, go to it's control panel.

--- a/google_custom_search_api.gemspec
+++ b/google_custom_search_api.gemspec
@@ -9,7 +9,6 @@ Gem::Specification.new do |s|
   s.authors     = ["Ben Wiseley"]
   s.email       = ["wiseleyb@gmail.com"]
   s.homepage    = "http://github.com/wiseleyb/google_custom_search_api"
-  s.date        = Date.today.to_s
   s.summary     = "Ruby lib for Google's Custom Search Api."
   s.description = "Ruby lib for Google's Custom Search Api."
   # s.files       = `git ls-files`.split("\n") - %w[google_custom_search_api.gemspec Gemfile init.rb]

--- a/lib/google_custom_search_api.rb
+++ b/lib/google_custom_search_api.rb
@@ -12,8 +12,10 @@ module GoogleCustomSearchApi
   ##
   # Search the site.
   #
-  # opts 
+  # opts
   #   see list here for valid options http://code.google.com/apis/customsearch/v1/using_rest.html#query-params
+  #   api_key: your google API key. Optional, else will look for constant
+  #   cx_id: your google custom search id. Optional, else will look for constant.
   def search(query, opts = {})
     # Get and parse results.
     url = url(query, opts)
@@ -108,13 +110,15 @@ module GoogleCustomSearchApi
   def url(query, opts = {})
     opts[:q] = query
     opts[:alt] ||= "json"
+    api_key = opts[:api_key] || GOOGLE_API_KEY
+    cx_id = opts[:cx_id] || GOOGLE_SEARCH_CX
     uri = Addressable::URI.new
     uri.query_values = opts
     begin
       params.merge!(GOOGLE_SEARCH_PARAMS)
     rescue NameError
     end
-    "https://www.googleapis.com/customsearch/v1?key=#{GOOGLE_API_KEY}&cx=#{GOOGLE_SEARCH_CX}&#{uri.query}"
+    "https://www.googleapis.com/customsearch/v1?key=#{api_key}&cx=#{cx_id}&#{uri.query}"
   end
   
   ##


### PR DESCRIPTION
I changed the code to also allow specifying a hash for the search options including the API key.
